### PR TITLE
Add Dockerfile for oetoolkits

### DIFF
--- a/oetoolkits/Dockerfile
+++ b/oetoolkits/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y wget libcairo2-dev
+# Configure environment
+ENV CONDA_DIR /opt/conda
+ENV PATH $CONDA_DIR/bin:$PATH
+ENV SHELL /bin/bash
+ENV OE_LICENSE /tmp/oe_license.txt
+
+# Install Conda with Python3
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-latest-Linux-x86_64.sh && \
+    /opt/conda/bin/conda update --quiet --yes conda && \
+    /opt/conda/bin/conda install --yes pip && \
+    /opt/conda/bin/pip install --upgrade pip
+
+# Install OE TKs
+COPY requirements.txt /tmp/requirements.txt
+RUN pip --no-cache-dir install -r /tmp/requirements.txt

--- a/oetoolkits/README.md
+++ b/oetoolkits/README.md
@@ -1,0 +1,5 @@
+Basic setup required for others to use OE Toolkits. Can be used as a 
+base image for other images requiring OE Tookits.
+ 
+To pass the license, when running your images add this: 
+`docker run ... -v /tmp/oe_license.txt:/tmp/oe_license.txt:ro ...`

--- a/oetoolkits/requirements.txt
+++ b/oetoolkits/requirements.txt
@@ -1,0 +1,5 @@
+## Non-Conda Packages ##
+#
+## OE Packages from Anaconda Repo ##
+--extra-index-url https://pypi.anaconda.org/OpenEye/simple
+OpenEye-toolkits


### PR DESCRIPTION
This image represents only the basic setup required for others to use
OE Toolkits. Needed because some tools require only the OE Toolkits to
work, example: https://github.com/OpenEye-Contrib/OEMicroservices/

Since this this the most basic setup, other images in this repo could
use it as the base image.